### PR TITLE
Fix workflow warning message from checkout action

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -2,7 +2,7 @@ name: Deploy Backend
 
 on:
   push:
-    branches: [deploy-with-sanity]
+    branches: [main]
     paths:
       - backend/**
 
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: npm install

--- a/backend/sanity.cli.ts
+++ b/backend/sanity.cli.ts
@@ -7,7 +7,7 @@ export default defineCliConfig({
   },
   graphql: [
     {
-      playground: false
+      playground: false,
     },
   ],
 })


### PR DESCRIPTION
Fixes the following warning message:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2
```

It also updates the branch back to `main`, which I forgot to do after testing.