### PR TITLE
Add priority to category schema

### DIFF
--- a/backend/schemas/category.ts
+++ b/backend/schemas/category.ts
@@ -10,6 +10,11 @@ export default defineType({
       name: 'name',
       title: 'Name',
     }),
+    defineField({
+      type: 'number',
+      name: 'priority',
+      title: 'Priority'
+    })
   ],
   preview: {
     select: {


### PR DESCRIPTION
Adds priority to category schema to allow sorting the categories later on in the frontend.