### PR TITLE
Prevent certain actions on menu singleton

### DIFF
--- a/backend/deskStructure.ts
+++ b/backend/deskStructure.ts
@@ -1,13 +1,25 @@
+import { DocumentActionsResolver } from 'sanity'
 import { StructureBuilder, StructureResolver } from 'sanity/desk'
 
-export const structure: StructureResolver = (S: StructureBuilder) =>
+export const deskAction: DocumentActionsResolver = (prev, context) => {
+  if (context.schemaType === 'menu') {
+    return prev.filter(({ action }) =>
+      action === 'publish'
+    )
+  }
+
+  return prev
+}
+
+export const deskStructure: StructureResolver = (S: StructureBuilder) =>
   S.list()
-  .title('Base')
+  .title('Content')
   .items([
     S.listItem()
       .title('Menu')
       .child(
-        S.document()
+        S.editor()
+          .id('menu')
           .schemaType('menu')
           .documentId('menu')),
           ...S.documentTypeListItems().filter(listItem => { 

--- a/backend/sanity.config.ts
+++ b/backend/sanity.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'sanity'
 import { deskTool } from 'sanity/desk'
 import { visionTool } from '@sanity/vision'
 
-import { structure } from './deskStructure'
+import { deskStructure, deskAction } from './deskStructure'
 import { schemaTypes } from './schemas'
 
 export default defineConfig({
@@ -13,9 +13,15 @@ export default defineConfig({
   dataset: 'production',
 
   plugins: [
-    deskTool({ structure }),
+    deskTool({
+      structure: deskStructure
+    }),
     visionTool()
   ],
+
+  document: {
+    actions: deskAction
+  },
 
   schema: {
     types: schemaTypes,


### PR DESCRIPTION
This prevents the user from doing anything to the Menu singleton except "publish".

Sadly, we can still create a new Menu document. But, that's going to be addressed on the frontend, for now, because we don't have any other option.