### PR TITLE
Use PDF menu as index page

### DIFF
--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -9,7 +9,7 @@ const NotFoundPage: React.FC = () => {
     <main className='text-slate-900'>
       <Background />
       <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
-        <Header />
+        <Header className='w-full' />
         <div className='w-full xl:w-2/3 xl:px-12 lg:w-5/6 lg:px-6'>
           <div className='pt-12 pb-4 px-6 md:pt-28 md:pb-12'>
             <h1 className='text-4xl font-bold mb-16'>Page Not Found</h1>

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { graphql } from 'gatsby'
+import type { HeadFC } from 'gatsby'
+
+import Menu from '../components/Menu'
+import Background from '../components/Background'
+import Header from '../components/Header'
+import Footer from '../components/Footer'
+import Seo from '../components/Seo'
+import { cleanMenu } from '../utils/cleaner'
+import PrintCompatibleContent from '../components/PrintCompatibleContent'
+
+type HomePageProps = {
+  data: {
+    sanityMenu: NullableSanityMenu
+  }
+}
+
+const HomePage: React.FC<HomePageProps> = ({ data }) =>
+  (
+    <main className='text-slate-900'>
+      <Seo />
+      <Background />
+      <div className='px-2 print:px-0 lg:px-16 print:lg:px-0 md:px-8 print:md:px-0'>
+        <PrintCompatibleContent
+          header={
+            <Header className='w-full' />
+          }
+          footer={
+            <Footer className='print:absolute w-full bottom-0' />
+          }
+        >
+          <Menu
+            className='w-full print:w-full print:px-8 xl:w-2/3 print:xl:w-full xl:px-12 print:xl:px-8 lg:w-5/6 print:lg:w-full lg:px-6 print:lg:px-8'
+            data={cleanMenu(data.sanityMenu)}
+          />
+        </PrintCompatibleContent>
+      </div>
+    </main>
+  )
+
+export default HomePage
+
+export const Head: HeadFC = () => <title>Al Kooz Café</title>
+
+export const query = graphql`
+{
+  sanityMenu(_id: { eq: "menu" }) {
+    categoryList {
+      name {
+        nameArabic
+        nameEnglish
+      }
+      itemList {
+        name {
+          nameArabic
+          nameEnglish
+        }
+        priceList {
+          amount
+          currency
+        }
+      }
+    }
+  }
+}
+`

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <object className='w-screen h-screen' data="https://docs.google.com/gview?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf" type="application/pdf">
+      <iframe className='w-screen h-screen' frameBorder={0} src='https://docs.google.com/gview?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf'>
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />
@@ -24,7 +24,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
             </div>
           </div>
         </div>
-      </object>
+      </iframe>
     </main>
   )
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -15,7 +15,11 @@ const IndexPage: React.FC<IndexPageProps> = ({}) => {
     <main className='text-slate-900'>
       <Seo />
 
-      <iframe className='w-screen h-screen' frameBorder={0} src={`https://docs.google.com/viewer?embedded=true&url=${pdfMenuUrl}`}>
+      <iframe
+        className='w-screen h-screen'
+        frameBorder={0}
+        src={`https://docs.google.com/viewer?embedded=true&url=${pdfMenuUrl}`}
+      >
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />
@@ -23,7 +27,12 @@ const IndexPage: React.FC<IndexPageProps> = ({}) => {
             <div className='pt-12 pb-4 px-6 md:pt-28 md:pb-12'>
               <h1 className='text-4xl font-bold mb-16'>Something went wrong</h1>
               <p>Looks like your browser cannot display the Menu</p>
-              <Link to='/Al%20Kooz%20Cafe%20—%20Menu.pdf' className='text-md font-normal'>Click here to download the Menu</Link>
+              <Link
+                to='/Al%20Kooz%20Cafe%20—%20Menu.pdf'
+                className='text-md font-normal'
+              >
+                Click here to download the Menu
+              </Link>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <object className='w-screen h-screen' data="/static/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
+      <object className='w-screen h-screen' data="/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react'
-import { HeadFC, Link } from 'gatsby'
+import { HeadFC, Link, PageProps } from 'gatsby'
 
 import Seo from '../components/Seo'
 import Background from '../components/Background'
 import Header from '../components/Header'
 
-type IndexPageProps = {}
-
-const IndexPage: React.FC<IndexPageProps> = ({}) => {
-  const baseUrl = window.location.href
-  const pdfMenuUrl = new URL('/Al Kooz Cafe — Menu.pdf', baseUrl)
+const IndexPage: React.FC<PageProps> = ({ location }) => {
+  const pdfMenuUrl = new URL('/Al Kooz Cafe — Menu.pdf', location.href)
 
   return (
     <main className='text-slate-900'>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,67 +1,21 @@
 import * as React from 'react'
-import { graphql } from 'gatsby'
 import type { HeadFC } from 'gatsby'
 
-import Menu from '../components/Menu'
-import Background from '../components/Background'
-import Header from '../components/Header'
-import Footer from '../components/Footer'
 import Seo from '../components/Seo'
-import { cleanMenu } from '../utils/cleaner'
-import PrintCompatibleContent from '../components/PrintCompatibleContent'
 
-type IndexPageProps = {
-  data: {
-    sanityMenu: NullableSanityMenu
-  }
-}
+type IndexPageProps = {}
 
-const IndexPage: React.FC<IndexPageProps> = ({ data }) =>
+const IndexPage: React.FC<IndexPageProps> = ({}) =>
   (
     <main className='text-slate-900'>
       <Seo />
-      <Background />
-      <div className='px-2 print:px-0 lg:px-16 print:lg:px-0 md:px-8 print:md:px-0'>
-        <PrintCompatibleContent
-          header={
-            <Header className='w-full' />
-          }
-          footer={
-            <Footer className='print:absolute w-full bottom-0' />
-          }
-        >
-          <Menu
-            className='w-full print:w-full print:px-8 xl:w-2/3 print:xl:w-full xl:px-12 print:xl:px-8 lg:w-5/6 print:lg:w-full lg:px-6 print:lg:px-8'
-            data={cleanMenu(data.sanityMenu)}
-          />
-        </PrintCompatibleContent>
-      </div>
+
+      <object className='w-screen h-screen' data="/static/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
+        <p>Looks like your browser can't display the menu — <a href="/static/Al%20Kooz%20Cafe%20—%20Menu.pdf">Click here to download it.</a></p>
+      </object>
     </main>
   )
 
 export default IndexPage
 
 export const Head: HeadFC = () => <title>Al Kooz Café</title>
-
-export const query = graphql`
-{
-  sanityMenu(_id: { eq: "menu" }) {
-    categoryList {
-      name {
-        nameArabic
-        nameEnglish
-      }
-      itemList {
-        name {
-          nameArabic
-          nameEnglish
-        }
-        priceList {
-          amount
-          currency
-        }
-      }
-    }
-  }
-}
-`

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
-import type { HeadFC } from 'gatsby'
+import { HeadFC, Link } from 'gatsby'
 
 import Seo from '../components/Seo'
+import Background from '../components/Background'
+import Header from '../components/Header'
 
 type IndexPageProps = {}
 
@@ -10,8 +12,18 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <object className='w-screen h-screen' data="/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
-        <p>Looks like your browser can't display the menu — <a href="/Al%20Kooz%20Cafe%20—%20Menu.pdf">Click here to download it.</a></p>
+      <object className='w-screen h-screen' data="/static/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
+        <Background />
+        <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
+          <Header className='w-full' />
+          <div className='w-full xl:w-2/3 xl:px-12 lg:w-5/6 lg:px-6'>
+            <div className='pt-12 pb-4 px-6 md:pt-28 md:pb-12'>
+              <h1 className='text-4xl font-bold mb-16'>Something went wrong</h1>
+              <p>Looks like your browser cannot display the Menu</p>
+              <Link to='/Al%20Kooz%20Cafe%20—%20Menu.pdf' className='text-md font-normal'>Click here to download the Menu</Link>
+            </div>
+          </div>
+        </div>
       </object>
     </main>
   )

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <object className='w-screen h-screen' data="/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
+      <object className='w-screen h-screen' data="https://docs.google.com/viewer?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf" type="application/pdf">
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -6,7 +6,12 @@ import Background from '../components/Background'
 import Header from '../components/Header'
 
 const IndexPage: React.FC<PageProps> = ({ location }) => {
-  const pdfMenuUrl = new URL('/Al Kooz Cafe — Menu.pdf', location.href)
+  const baseUrl = location.href || 'https://alkoozcafe.com/'
+
+  const pdfMenuUrl = new URL(
+    '/Al Kooz Cafe — Menu.pdf',
+    baseUrl
+  )
 
   return (
     <main className='text-slate-900'>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <object className='w-screen h-screen' data="https://docs.google.com/viewer?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf" type="application/pdf">
+      <object className='w-screen h-screen' data="https://docs.google.com/gview?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf" type="application/pdf">
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,7 +12,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <iframe className='w-screen h-screen' frameBorder={0} src='https://docs.google.com/gview?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf'>
+      <iframe className='w-screen h-screen' frameBorder={0} src='https://docs.google.com/viewer?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf'>
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -7,12 +7,15 @@ import Header from '../components/Header'
 
 type IndexPageProps = {}
 
-const IndexPage: React.FC<IndexPageProps> = ({}) =>
-  (
+const IndexPage: React.FC<IndexPageProps> = ({}) => {
+  const baseUrl = window.location.href
+  const pdfMenuUrl = new URL('/Al Kooz Cafe — Menu.pdf', baseUrl)
+
+  return (
     <main className='text-slate-900'>
       <Seo />
 
-      <iframe className='w-screen h-screen' frameBorder={0} src='https://docs.google.com/viewer?embedded=true&url=https://deploy-preview-25--alkoozcafe-frontend.netlify.app/Al%20Kooz%20Cafe%20%E2%80%94%20Menu.pdf'>
+      <iframe className='w-screen h-screen' frameBorder={0} src={`https://docs.google.com/viewer?embedded=true&url=${pdfMenuUrl}`}>
         <Background />
         <div className='px-2 lg:px-24 lg:px-16 md:px-8'>
           <Header className='w-full' />
@@ -27,6 +30,7 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
       </iframe>
     </main>
   )
+}
 
 export default IndexPage
 

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -10,8 +10,8 @@ const IndexPage: React.FC<IndexPageProps> = ({}) =>
     <main className='text-slate-900'>
       <Seo />
 
-      <object className='w-screen h-screen' data="/static/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
-        <p>Looks like your browser can't display the menu — <a href="/static/Al%20Kooz%20Cafe%20—%20Menu.pdf">Click here to download it.</a></p>
+      <object className='w-screen h-screen' data="/Al%20Kooz%20Cafe%20—%20Menu.pdf" type="application/pdf">
+        <p>Looks like your browser can't display the menu — <a href="/Al%20Kooz%20Cafe%20—%20Menu.pdf">Click here to download it.</a></p>
       </object>
     </main>
   )


### PR DESCRIPTION
Uses the PDF menu as an index page and moves the previous index page to `/home`. 

This allows me to address the requests by the client, but also helps keep the page which I use to generate the PDF menu, which will remain updated thanks to Sanity.